### PR TITLE
chore(release): v0.1.0-alpha.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        id: changelog
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -164,7 +175,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.content }}
           files: release-assets/*
           fail_on_unmatched_files: false
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-index"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "bumpalo",
  "insta",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-lsp"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-mcp"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "markymark-parser"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "insta",
  "markymark-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sethyanow/markymark"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,54 @@
+# git-cliff configuration for markymark
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to markymark will be documented in this file.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/sethyanow/markymark
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+            ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+    {%- endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore\\(deps\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+]
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"

--- a/markymark-cli/Cargo.toml
+++ b/markymark-cli/Cargo.toml
@@ -14,9 +14,9 @@ name = "markymark"
 path = "src/main.rs"
 
 [dependencies]
-markymark-core = { version = "=0.1.0-alpha.1", path = "../markymark-core" }
-markymark-lsp = { version = "=0.1.0-alpha.1", path = "../markymark-lsp" }
-markymark-mcp = { version = "=0.1.0-alpha.1", path = "../markymark-mcp" }
+markymark-core = { version = "=0.1.0-alpha.2", path = "../markymark-core" }
+markymark-lsp = { version = "=0.1.0-alpha.2", path = "../markymark-lsp" }
+markymark-mcp = { version = "=0.1.0-alpha.2", path = "../markymark-mcp" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }

--- a/markymark-index/Cargo.toml
+++ b/markymark-index/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["markdown", "index", "cross-reference", "workspace"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-markymark-core = { version = "=0.1.0-alpha.1", path = "../markymark-core" }
-markymark-parser = { version = "=0.1.0-alpha.1", path = "../markymark-parser" }
+markymark-core = { version = "=0.1.0-alpha.2", path = "../markymark-core" }
+markymark-parser = { version = "=0.1.0-alpha.2", path = "../markymark-parser" }
 petgraph = { workspace = true }
 bumpalo = { workspace = true }
 serde = { workspace = true }

--- a/markymark-lsp/Cargo.toml
+++ b/markymark-lsp/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["markdown", "lsp", "language-server", "editor"]
 categories = ["development-tools", "text-editors"]
 
 [dependencies]
-markymark-core = { version = "=0.1.0-alpha.1", path = "../markymark-core" }
-markymark-parser = { version = "=0.1.0-alpha.1", path = "../markymark-parser" }
-markymark-index = { version = "=0.1.0-alpha.1", path = "../markymark-index" }
+markymark-core = { version = "=0.1.0-alpha.2", path = "../markymark-core" }
+markymark-parser = { version = "=0.1.0-alpha.2", path = "../markymark-parser" }
+markymark-index = { version = "=0.1.0-alpha.2", path = "../markymark-index" }
 tower-lsp-server = { workspace = true }
 lsp-types = { workspace = true }
 tokio = { workspace = true }

--- a/markymark-mcp/Cargo.toml
+++ b/markymark-mcp/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["markdown", "mcp", "ai", "language-server"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-markymark-core = { version = "=0.1.0-alpha.1", path = "../markymark-core" }
-markymark-parser = { version = "=0.1.0-alpha.1", path = "../markymark-parser" }
-markymark-index = { version = "=0.1.0-alpha.1", path = "../markymark-index" }
+markymark-core = { version = "=0.1.0-alpha.2", path = "../markymark-core" }
+markymark-parser = { version = "=0.1.0-alpha.2", path = "../markymark-parser" }
+markymark-index = { version = "=0.1.0-alpha.2", path = "../markymark-index" }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/markymark-parser/Cargo.toml
+++ b/markymark-parser/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["markdown", "parser", "tree-sitter", "obsidian"]
 categories = ["parsing", "text-processing"]
 
 [dependencies]
-markymark-core = { version = "=0.1.0-alpha.1", path = "../markymark-core" }
+markymark-core = { version = "=0.1.0-alpha.2", path = "../markymark-core" }
 tree-sitter = { workspace = true }
 tree-sitter-markdown = { workspace = true }
 tree-sitter-xml = { workspace = true }

--- a/markymark-plugin/.claude-plugin/plugin.json
+++ b/markymark-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markymark",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "High-performance Markdown language server with LSP and MCP support. Provides go-to-definition, find-references, hover, completion, rename, diagnostics, and document symbols for Markdown files including wiki links, XML tags, and cross-document references.",
   "author": {
     "name": "Seth Yanow"


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.1.0-alpha.2
- Add git-cliff changelog generation to release workflow
- Includes download-on-first-run fallback from PR #3

## Changes
- All Cargo.toml versions: 0.1.0-alpha.1 → 0.1.0-alpha.2
- plugin.json version bumped
- New: `cliff.toml` (git-cliff config for conventional commit changelog)
- Updated: `release.yml` (fetch-depth: 0, git-cliff step, changelog in release body)

## Test plan
- [x] 340 Rust tests passing
- [x] 15 plugin tests passing
- [x] `cargo run -- --version` shows 0.1.0-alpha.2
- [ ] Tag and verify CI release with changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.0-alpha.2 across all workspace packages
  * Enhanced release workflow with automated changelog generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->